### PR TITLE
Adds build URL to end of Slack message if defined

### DIFF
--- a/lib/vidar/cli.rb
+++ b/lib/vidar/cli.rb
@@ -117,6 +117,7 @@ module Vidar
         github:        Config.get!(:github),
         revision:      Config.get!(:revision),
         revision_name: Config.get!(:revision_name),
+        build_url:     Config.build_url,
         deploy_config: Config.deploy_config
       )
 
@@ -194,6 +195,7 @@ module Vidar
         github:        Config.get!(:github),
         revision:      Config.get!(:revision),
         revision_name: Config.get!(:revision_name),
+        build_url:     Config.build_url,
         deploy_config: Config.deploy_config
       )
 

--- a/lib/vidar/config.rb
+++ b/lib/vidar/config.rb
@@ -52,6 +52,11 @@ module Vidar
         get(key) || fail(MissingConfigError, key)
       end
 
+      def build_url
+        value = ENV[get(:build_env).to_s]
+        value&.empty? ? nil : value
+      end
+
       def deploy_config
         deployments = get(:deployments)
         deployments = {} unless deployments.is_a?(Hash)

--- a/lib/vidar/slack_notification.rb
+++ b/lib/vidar/slack_notification.rb
@@ -1,9 +1,11 @@
 module Vidar
   class SlackNotification
-    def initialize(github:, revision:, revision_name:, deploy_config:)
+    def initialize(github:, revision:, revision_name:, deploy_config:, build_url: nil)
       @github          = github
       @revision        = revision
       @revision_name   = revision_name
+      @build_url       = build_url
+      @build_hostname  = URI(build_url || '').hostname
       @deploy_name     = deploy_config.name
       @deploy_url      = deploy_config.url
       @default_color   = deploy_config.default_color
@@ -18,12 +20,12 @@ module Vidar
     end
 
     def failure
-      message = "Failed deploy of #{github_link} to #{deploy_link} :fire: <!channel>"
+      message = "Failed deploy of #{github_link} to #{deploy_link} :fire: <!channel> #{build_link}"
       perform_with data(message: message, color: failure_color)
     end
 
     def success
-      message = "Successful deploy of #{github_link} to #{deploy_link}"
+      message = "Successful deploy of #{github_link} to #{deploy_link}. #{build_link}"
       perform_with data(message: message, color: success_color)
     end
 
@@ -44,7 +46,7 @@ module Vidar
     attr_reader :github, :revision, :revision_name,
       :deploy_name, :deploy_url, :webhook_url,
       :default_color, :success_color, :failure_color,
-      :connection
+      :connection, :build_url, :build_hostname
 
     def data(message:, color:)
       {
@@ -70,6 +72,10 @@ module Vidar
 
     def deploy_link
       "<#{deploy_url}|#{deploy_name}>"
+    end
+
+    def build_link
+      build_url && "<#{build_url}|View the build on #{build_hostname}>"
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -30,4 +30,34 @@ RSpec.describe Vidar::Config do
       expect { described_class.get!("invalid") }.to raise_error(Vidar::MissingConfigError)
     end
   end
+
+  describe '.build_url' do
+    subject { described_class.build_url }
+
+    specify { expect(subject).to eq nil }
+
+    context 'when build_url is defined in yaml' do
+      let(:env_key) { 'TRAVIS_BUILD_WEB_URL' }
+      let(:env_value) { nil }
+
+      before do
+        allow(described_class).to receive(:get).with(:build_env) { env_key }
+        allow(ENV).to receive(:[]).with(env_key) { env_value }
+      end
+
+      specify { expect(subject).to eq nil }
+
+      context 'when ENV[build_url] is set to a URL' do
+        let(:env_value) { 'https://ci.company.com/builds/123' }
+
+        specify { expect(subject).to eq env_value }
+      end
+
+      context 'when ENV[build_url] is set to a blank string' do
+        let(:env_value) { '' }
+
+        specify { expect(subject).to eq nil }
+      end
+    end
+  end
 end

--- a/spec/slack_notification_spec.rb
+++ b/spec/slack_notification_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Vidar::SlackNotification do
       github:        "RenoFi/vidar",
       revision:      "059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd",
       revision_name: "Release 1.0.0",
+      build_url:     "https://ci.company.com/builds/123",
       deploy_config: deploy_config,
     )
   end
@@ -38,8 +39,8 @@ RSpec.describe Vidar::SlackNotification do
             title: "RenoFi/vidar",
             title_link: "https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd",
             color: "ff1100",
-            text: "Failed deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging> :fire: <!channel>", # rubocop:disable Metrics/LineLength
-            fallback: "Failed deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging> :fire: <!channel>" # rubocop:disable Metrics/LineLength
+            text: "Failed deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging> :fire: <!channel> <https://ci.company.com/builds/123|View the build on ci.company.com>", # rubocop:disable Metrics/LineLength
+            fallback: "Failed deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging> :fire: <!channel> <https://ci.company.com/builds/123|View the build on ci.company.com>" # rubocop:disable Metrics/LineLength
           }
         ]
       }
@@ -59,8 +60,8 @@ RSpec.describe Vidar::SlackNotification do
             title: "RenoFi/vidar",
             title_link: "https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd",
             color: "008800",
-            text: "Successful deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging>", # rubocop:disable Metrics/LineLength
-            fallback: "Successful deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging>" # rubocop:disable Metrics/LineLength
+            text: "Successful deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging>. <https://ci.company.com/builds/123|View the build on ci.company.com>", # rubocop:disable Metrics/LineLength
+            fallback: "Successful deploy of <https://github.com/RenoFi/vidar/commit/059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd|Release 1.0.0> to <https://console.cloud.google.com/kubernetes/workload?namespace=foo|staging>. <https://ci.company.com/builds/123|View the build on ci.company.com>" # rubocop:disable Metrics/LineLength
           }
         ]
       }


### PR DESCRIPTION
Fixes #16 - Adds build URL to Slack notification

Define the `build_env` key inside of vidar.yml to enable this feature.
```
  ---
  build_env: "TRAVIS_BUILD_WEB_URL"
```
When this configuration key is set, the value is used to get the ENV
variable and use it in the Slack notification.  If it is not set, or is
set to an empty string, then the Slack notification does not include the
link.