### PR TITLE
Add support for creating Honeycomb markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.7.0 - 2023-01-23
+
+Add support for publishing Honeycomb markers on deployment.
+
 ## 1.6.0 - 2022-12-07
 
 Allow more complex deployments. By passing extra options to the deployment command, we allow deployments where there are multiple containers per pod or where there is more than just deployments/cronjobs (like deamonsets or something similar).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vidar (1.6.0)
+    vidar (1.7.0)
       colorize
       faraday
       thor (~> 1.0)
@@ -18,7 +18,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    faraday (2.7.3)
+    faraday (2.7.4)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ image: gcr.io/[GCP-PROJECT-ID]/[APP-NAME]
 namespace: borrower
 # github name used to build deployment notification content
 github: RenoFi/vidar
+# The key to use for creating honeycomb markers, defaults to HONEYCOMB_API_KEY env var
+honeycomb_api_key: secret
 # deployments config per kubectl context, required for `monitor_deploy_status` command
 deployments:
   gke_project_us-east4_staging:
@@ -88,6 +90,8 @@ deployments:
     sentry_webhook_url: https://sentry.io/api/hooks/release/builtin/123/asdf/
     # Slack webhook url used to send deploy notifications, optional
     slack_webhook_url: https://hooks.slack.com/services/ASCKNZ0vug2R3Ydo/ASCKNZ0vug2R3Ydo/ASCKNZ0vug2R3Ydo
+    # Name of the Honeycomb dataset to create a deployment marker in
+    honeycomb_dataset: staging
 # docker-compose file, optional, default value: docker-compose.ci.yml
 compose_file: docker-compose.ci.yml
 # default_branch, optional, default value: main or master (auto-detected from local branches)

--- a/lib/vidar.rb
+++ b/lib/vidar.rb
@@ -10,6 +10,7 @@ require 'thor'
 
 require 'vidar/version'
 require 'vidar/config'
+require 'vidar/honeycomb_notification'
 require 'vidar/interpolation'
 require 'vidar/log'
 require 'vidar/run'

--- a/lib/vidar/config.rb
+++ b/lib/vidar/config.rb
@@ -14,6 +14,7 @@ module Vidar
       console_command:    -> { "bin/console" },
       base_stage_name:    -> { "base" },
       release_stage_name: -> { "release" },
+      honeycomb_api_key: -> { ENV['HONEYCOMB_API_KEY'] },
     }.freeze
 
     class << self

--- a/lib/vidar/deploy_config.rb
+++ b/lib/vidar/deploy_config.rb
@@ -6,7 +6,7 @@ module Vidar
 
     attr_reader :name, :url,
       :default_color, :success_color, :failure_color,
-      :slack_webhook_url, :sentry_webhook_url
+      :slack_webhook_url, :sentry_webhook_url, :honeycomb_dataset
 
     def initialize(options)
       @name = options.fetch(:name)
@@ -18,6 +18,7 @@ module Vidar
 
       @slack_webhook_url = options[:slack_webhook_url]
       @sentry_webhook_url = options[:sentry_webhook_url]
+      @honeycomb_dataset = options[:honeycomb_dataset]
     end
   end
 end

--- a/lib/vidar/honeycomb_notification.rb
+++ b/lib/vidar/honeycomb_notification.rb
@@ -1,0 +1,87 @@
+module Vidar
+  class HoneycombNotification
+    def self.get
+      new(
+        github:        Config.get!(:github),
+        revision:      Config.get!(:revision),
+        revision_name: Config.get!(:revision_name),
+        build_url:     Config.build_url,
+        deploy_config: Config.deploy_config,
+        api_key: Config.get(:honeycomb_api_key),
+      )
+    end
+
+    def initialize(github:, revision:, revision_name:, deploy_config:, build_url: nil, api_key: nil, connection: Faraday.new)
+      @github = github
+      @revision = revision
+      @revision_name = revision_name
+      @build_url = build_url
+      @api_key = api_key
+      @dataset = deploy_config.honeycomb_dataset
+      @connection = connection
+      @start_time = Time.now.utc
+      @end_time = nil
+      @success = false
+    end
+
+    def configured?
+      !dataset.nil? && !api_key.nil?
+    end
+
+    def success
+      @end_time = Time.now.utc
+      @success = true
+
+      call
+    end
+
+    def failure
+      @end_time = Time.now.utc
+      @success = false
+
+      call
+    end
+
+    private
+
+    attr_reader :connection,
+      :github,
+      :revision,
+      :revision_name,
+      :dataset,
+      :build_url,
+      :api_key,
+      :start_time,
+      :end_time
+
+    def success?
+      @success
+    end
+
+    def call
+      return false unless configured?
+
+      response = connection.post do |req|
+        req.url "https://api.honeycomb.io/1/markers/#{dataset}"
+        req.headers['Content-Type'] = 'application/json'
+        req.headers['X-Honeycomb-Team'] = api_key.to_s
+        req.body = data.to_json
+      end
+
+      return true if response.status == 201
+
+      warn "Honeycomb marker not created: status: #{response.status} response: #{response.body}"
+      false
+    end
+
+    def data
+      {
+        message: "#{success? ? 'Successful' : 'Failed'} deploy of #{github} revision #{revision} - #{revision_name}",
+        type: success? ? "deploy" : "failed_deploy",
+        start_time: start_time.to_i,
+        end_time: end_time.to_i,
+        url: build_url,
+      }
+    end
+  end
+end

--- a/lib/vidar/version.rb
+++ b/lib/vidar/version.rb
@@ -1,3 +1,3 @@
 module Vidar
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.7.0'.freeze
 end

--- a/spec/vidar/honeycomb_notification_spec.rb
+++ b/spec/vidar/honeycomb_notification_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Vidar::HoneycombNotification do
+  subject do
+    described_class.new(
+      github:        "RenoFi/vidar",
+      revision:      "059082da8b8733d46a9a9a3d82e3a7afa8cf8cbd",
+      revision_name: "Release 1.0.0",
+      build_url:     "https://ci.company.com/builds/123",
+      deploy_config: deploy_config,
+      api_key:       api_key,
+    )
+  end
+
+  let(:deploy_config) do
+    Vidar::DeployConfig.new(
+      name: "staging",
+      url: "https://console.cloud.google.com/kubernetes/workload?namespace=foo",
+      honeycomb_dataset: dataset,
+    )
+  end
+
+  let(:api_key) { "secret" }
+  let(:dataset) { "foo" }
+
+  context "when not configured" do
+    let(:dataset) { nil }
+
+    it "does not send a success notification" do
+      expect(subject.success).to be(false)
+    end
+
+    it "does not send a failure notification" do
+      expect(subject.failure).to be(false)
+    end
+  end
+
+  describe "#success" do
+    it "sends a notification" do
+      stub_request(:post, "https://api.honeycomb.io/1/markers/foo")
+        .with(headers: { "Content-Type" => "application/json", "X-Honeycomb-Team" => "secret" })
+        .to_return(status: 201)
+
+      expect(subject.success).to be(true)
+    end
+  end
+
+  describe "#failure" do
+    it "sends a notification" do
+      stub_request(:post, "https://api.honeycomb.io/1/markers/foo")
+        .with(headers: { "Content-Type" => "application/json", "X-Honeycomb-Team" => "secret" })
+        .to_return(status: 201)
+
+      expect(subject.failure).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Description, motivation and context

Markers show up as vertical lines in honeycomb graphs. They can make it easier to spot problems, when the issue is directly correlated to a deployment.