### PR TITLE
Add support for HTTPS_PROXY automatically set for each kubectl command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.8.0 - 2023-06-02
+
+Add support for HTTPS_PROXY automatically set for each kubectl command
+
 ## 1.7.0 - 2023-01-23
 
 Add support for publishing Honeycomb markers on deployment.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vidar (1.7.1)
+    vidar (1.8.0)
       colorize
       faraday
       thor (~> 1.0)
@@ -59,7 +59,7 @@ GEM
       rubocop-ast (>= 1.28.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.28.1)
+    rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
     rubocop-capybara (2.18.0)
       rubocop (~> 1.41)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ deployments:
     slack_webhook_url: https://hooks.slack.com/services/ASCKNZ0vug2R3Ydo/ASCKNZ0vug2R3Ydo/ASCKNZ0vug2R3Ydo
     # Name of the Honeycomb dataset to create a deployment marker in
     honeycomb_dataset: staging
+    # https_proxy address used to connect private k8s control plane endpoint
+    https_proxy: localhost:8888
 # docker-compose file, optional, default value: docker-compose.ci.yml
 compose_file: docker-compose.ci.yml
 # default_branch, optional, default value: main or master (auto-detected from local branches)

--- a/lib/vidar/cli.rb
+++ b/lib/vidar/cli.rb
@@ -14,6 +14,11 @@ module Vidar
       Run.docker_compose("run #{target} #{options[:command]}") || exit(1)
     end
 
+    desc "version", "Prints current version"
+    def version
+      puts Vidar::VERSION
+    end
+
     desc "pull", "Pull existing docker images to leverage docker caching"
     def pull
       Log.info "Pulling #{Config.get!(:image)} tags"

--- a/lib/vidar/deploy_config.rb
+++ b/lib/vidar/deploy_config.rb
@@ -6,7 +6,8 @@ module Vidar
 
     attr_reader :name, :url,
       :default_color, :success_color, :failure_color,
-      :slack_webhook_url, :sentry_webhook_url, :honeycomb_dataset
+      :slack_webhook_url, :sentry_webhook_url, :honeycomb_dataset,
+      :https_proxy
 
     def initialize(options)
       @name = options.fetch(:name)
@@ -19,6 +20,8 @@ module Vidar
       @slack_webhook_url = options[:slack_webhook_url]
       @sentry_webhook_url = options[:sentry_webhook_url]
       @honeycomb_dataset = options[:honeycomb_dataset]
+
+      @https_proxy = options[:https_proxy]
     end
   end
 end

--- a/lib/vidar/k8s/pod_set.rb
+++ b/lib/vidar/k8s/pod_set.rb
@@ -52,9 +52,9 @@ module Vidar
 
       def kubectl_get
         if namespace == "all"
-          `kubectl get pods --all-namespaces -o json`
+          `#{Run.kubectl_envs_string}kubectl get pods --all-namespaces -o json`
         else
-          `kubectl get pods -n #{namespace} -o json`
+          `#{Run.kubectl_envs_string}kubectl get pods -n #{namespace} -o json`
         end
       end
 

--- a/lib/vidar/run.rb
+++ b/lib/vidar/run.rb
@@ -10,8 +10,13 @@ module Vidar
         system("#{args.join(' ')} docker-compose -f #{Config.get!(:compose_file)} #{command}") || exit(1)
       end
 
-      def kubectl(command)
-        system("kubectl --namespace=#{Config.get!(:namespace)} #{command}") || exit(1)
+      def kubectl(command, namespace: Config.get!(:namespace))
+        system("#{kubectl_envs_string}kubectl --namespace=#{namespace} #{command}") || exit(1)
+      end
+
+      def kubectl_envs_string
+        https_proxy = Config.deploy_config.https_proxy
+        "HTTPS_PROXY=#{https_proxy} " if https_proxy
       end
     end
   end

--- a/lib/vidar/version.rb
+++ b/lib/vidar/version.rb
@@ -1,3 +1,3 @@
 module Vidar
-  VERSION = '1.7.1'.freeze
+  VERSION = '1.8.0'.freeze
 end


### PR DESCRIPTION
## Description, motivation and context
When `kubectl` used private control plane endpoint it requires setting HTTPS_PROXY variable. Having HTTPS_PROXY set globally bring a lot of problems, since it's used by many other tools.

With this PR we can define `https_proxy` for each deployment and it's added for each `kubectl` command.