### PR TITLE
Fix monitor_deploy_status forwarding --max_tries to notify_sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.17.1 - 2026-05-19
+
+- Fix `monitor_deploy_status` failing the deploy promotion when `--max_tries` is passed: Thor's `invoke :notify_sentry` was forwarding the parent task's ARGV as positional args. Pass explicit empty args/options to scope the sub-invocation.
+
 ## 1.17.0 - 2026-03-24
 
 - Replace backtick shell calls with `Open3.capture3` for safer command execution

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vidar (1.17.0)
+    vidar (1.17.1)
       colorize
       faraday (>= 2.0, < 3)
       thor (~> 1.0)

--- a/lib/vidar/cli.rb
+++ b/lib/vidar/cli.rb
@@ -179,7 +179,7 @@ module Vidar
         Log.info "OK: All containers are ready"
         slack_notification.success if slack_notification.configured?
         honeycomb_notification.success
-        invoke :notify_sentry
+        invoke :notify_sentry, [], {}
       else
         Log.error "ERROR: Some of containers are errored or not ready"
         slack_notification.failure if slack_notification.configured?

--- a/lib/vidar/version.rb
+++ b/lib/vidar/version.rb
@@ -1,3 +1,3 @@
 module Vidar
-  VERSION = "1.17.0".freeze
+  VERSION = "1.17.1".freeze
 end

--- a/spec/vidar/cli_spec.rb
+++ b/spec/vidar/cli_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe Vidar::CLI do
+  describe "monitor_deploy_status" do
+    let(:deploy_status) { instance_double(Vidar::DeployStatus, wait_until_completed: nil, success?: true) }
+    let(:slack_notification) { instance_double(Vidar::SlackNotification, configured?: false) }
+    let(:honeycomb_notification) { instance_double(Vidar::HoneycombNotification, success: nil) }
+    let(:sentry_notification) { instance_double(Vidar::SentryNotification, configured?: false) }
+    let(:deploy_config) { Vidar::DeployConfig.new(name: "staging") }
+
+    before do
+      allow(Vidar::Config).to receive(:get!).and_call_original
+      allow(Vidar::Config).to receive(:get!).with(:revision).and_return("abc123")
+      allow(Vidar::Config).to receive(:get!).with(:kubectl_context).and_return("staging")
+      allow(Vidar::Config).to receive(:deploy_config).and_return(deploy_config)
+      allow(Vidar::DeployStatus).to receive(:new).and_return(deploy_status)
+      allow(Vidar::SlackNotification).to receive(:get).and_return(slack_notification)
+      allow(Vidar::HoneycombNotification).to receive(:get).and_return(honeycomb_notification)
+      allow(Vidar::SentryNotification).to receive(:new).and_return(sentry_notification)
+    end
+
+    it "invokes notify_sentry without forwarding parent options as positional args" do
+      expect(Vidar::SentryNotification).to receive(:new).with(revision: "abc123", deploy_config:)
+
+      expect { Vidar::CLI.start(["monitor_deploy_status", "--max_tries=1"]) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Deploy promotions are currently failing with:
  ```
  ERROR: "vidar notify_sentry" was called with arguments ["--max_tries=90"]
  Usage: "vidar notify_sentry"
  ```
- Root cause: Thor's `invoke :notify_sentry` (without explicit args/options) forwards the parent task's ARGV. When the promotion runs `vidar monitor_deploy_status --max_tries=90`, that `--max_tries=90` token gets re-parsed by Thor as a positional arg for `notify_sentry`, which accepts none.
- Fix: pass explicit empty args and options to `invoke` so the sub-invocation has clean state. Matches the existing `invoke :kube_exec, [], name:, command:` pattern elsewhere in the CLI.
- Bumped to 1.17.1; added a regression spec that exercises `Vidar::CLI.start(["monitor_deploy_status", "--max_tries=1"])` and asserts no exit and that `SentryNotification.new` is called.

## Test plan

- [x] `bundle exec rake ci` (149 examples, 0 failures; 32 files no offenses)
- [x] New spec fails on `main` (confirmed by reverting fix locally) and passes with the fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)