### PR TITLE
Remove required key validation from vidar.yml schema check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.17.2 - 2026-05-21
+
+- Remove required key validation from `vidar.yml` — config loads without requiring any top-level keys; deployments structure is still validated
+
 ## 1.17.1 - 2026-05-19
 
 - Fix `monitor_deploy_status` failing the deploy promotion when `--max_tries` is passed: Thor's `invoke :notify_sentry` was forwarding the parent task's ARGV as positional args. Pass explicit empty args/options to scope the sub-invocation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vidar (1.17.1)
+    vidar (1.17.2)
       colorize
       faraday (>= 2.0, < 3)
       thor (~> 1.0)

--- a/lib/vidar/config.rb
+++ b/lib/vidar/config.rb
@@ -4,8 +4,6 @@ module Vidar
   class Config
     DEFAULT_MANIFEST_FILE = "vidar.yml".freeze
     DEFAULT_BRANCHES = %w[main master].freeze
-    REQUIRED_KEYS = %w[image namespace github].freeze
-
     DEFAULT_OPTIONS = {
       compose_file: -> { "docker-compose.ci.yml" },
       compose_cmd: -> { "docker compose" },
@@ -26,10 +24,8 @@ module Vidar
       attr_reader :data
       attr_writer :manifest_file
 
-      # Loads the manifest file and validates required keys.
       # @param file_path [String] path to vidar.yml
       # @raise [MissingManifestFileError] if the file does not exist
-      # @raise [Error] if required keys are missing or schema is invalid
       def load(file_path = manifest_file)
         ensure_file_exist!(file_path)
 
@@ -122,9 +118,6 @@ module Vidar
       private
 
       def validate_schema!
-        missing = REQUIRED_KEYS.reject { |k| @data.key?(k) }
-        fail(Error, "vidar.yml is missing required keys: #{missing.join(", ")}") if missing.any?
-
         deployments = @data["deployments"]
         fail(Error, "vidar.yml: 'deployments' must be a Hash, got #{deployments.class}") if deployments && !deployments.is_a?(Hash)
 

--- a/lib/vidar/version.rb
+++ b/lib/vidar/version.rb
@@ -1,3 +1,3 @@
 module Vidar
-  VERSION = "1.17.1".freeze
+  VERSION = "1.17.2".freeze
 end

--- a/spec/vidar/config_spec.rb
+++ b/spec/vidar/config_spec.rb
@@ -12,16 +12,8 @@ RSpec.describe Vidar::Config do
 
     after { tmp_file.unlink }
 
-    context "when a required key is missing" do
-      before { tmp_file.write({"namespace" => "x", "github" => "x"}.to_yaml) && tmp_file.flush }
-
-      it "raises an error listing the missing key" do
-        expect { described_class.load(tmp_file.path) }.to raise_error(Vidar::Error, /image/)
-      end
-    end
-
     context "when deployments is not a Hash" do
-      before { tmp_file.write({"image" => "x", "namespace" => "x", "github" => "x", "deployments" => "bad"}.to_yaml) && tmp_file.flush }
+      before { tmp_file.write({"namespace" => "x", "github" => "x", "deployments" => "bad"}.to_yaml) && tmp_file.flush }
 
       it "raises an error" do
         expect { described_class.load(tmp_file.path) }.to raise_error(Vidar::Error, /deployments/)
@@ -30,7 +22,7 @@ RSpec.describe Vidar::Config do
 
     context "when a deployment entry is missing name" do
       before do
-        tmp_file.write({"image" => "x", "namespace" => "x", "github" => "x", "deployments" => {"ctx" => {"url" => "http://x"}}}.to_yaml)
+        tmp_file.write({"namespace" => "x", "github" => "x", "deployments" => {"ctx" => {"url" => "http://x"}}}.to_yaml)
         tmp_file.flush
       end
 


### PR DESCRIPTION
## Summary

- Removes `REQUIRED_KEYS` check — config loads without requiring `image`, `namespace`, or `github`
- Keeps the `deployments` structure validation (must be a Hash, each entry must be a Hash with a `name` key)

## Motivation

Not all vidar workflows build or push an image. Some commands — like `monitor_deploy_status` run across all namespaces — only need cluster and repo context. Requiring specific top-level keys blocks loading the config for those use cases.