### PR TITLE
Sanitize all invalid docker tag chars in current_branch

### DIFF
--- a/lib/vidar/config.rb
+++ b/lib/vidar/config.rb
@@ -8,7 +8,7 @@ module Vidar
       compose_file: -> { "docker-compose.ci.yml" },
       compose_cmd: -> { "docker compose" },
       default_branch: -> { (DEFAULT_BRANCHES & branches).first || DEFAULT_BRANCHES.first },
-      current_branch: -> { (ENV["SEMAPHORE_GIT_WORKING_BRANCH"] || shell_capture("git rev-parse --abbrev-ref HEAD")).gsub(/[^a-zA-Z0-9_.]+/, "-").gsub(/\A-|-\z/, "") },
+      current_branch: -> { (ENV["SEMAPHORE_GIT_WORKING_BRANCH"] || shell_capture("git rev-parse --abbrev-ref HEAD")).gsub(/[^a-zA-Z0-9_]+/, "-").gsub(/\A-|-\z/, "") },
       revision: -> { shell_capture("git rev-parse HEAD") },
       revision_name: -> { shell_capture('git show --pretty=format:"%s (%h)" -s HEAD') },
       kubectl_context: -> { shell_capture("kubectl config current-context") },

--- a/lib/vidar/config.rb
+++ b/lib/vidar/config.rb
@@ -8,7 +8,7 @@ module Vidar
       compose_file: -> { "docker-compose.ci.yml" },
       compose_cmd: -> { "docker compose" },
       default_branch: -> { (DEFAULT_BRANCHES & branches).first || DEFAULT_BRANCHES.first },
-      current_branch: -> { (ENV["SEMAPHORE_GIT_WORKING_BRANCH"] || shell_capture("git rev-parse --abbrev-ref HEAD")).tr("/", "-") },
+      current_branch: -> { (ENV["SEMAPHORE_GIT_WORKING_BRANCH"] || shell_capture("git rev-parse --abbrev-ref HEAD")).gsub(/[^a-zA-Z0-9_.]+/, "-").gsub(/\A-|-\z/, "") },
       revision: -> { shell_capture("git rev-parse HEAD") },
       revision_name: -> { shell_capture('git show --pretty=format:"%s (%h)" -s HEAD') },
       kubectl_context: -> { shell_capture("kubectl config current-context") },


### PR DESCRIPTION
## Summary
- `current_branch` previously only replaced `/` with `-`, so branch names containing characters like `$%^&#` produced invalid docker image tags.
- Now any run of characters outside `[a-zA-Z0-9_]` (including `/`, `.`, and repeated `-`) collapses to a single `-`, and leading/trailing dashes are stripped.

Example: `$feat/foo$%.^&#bar--baz--` → `feat-foo-bar-baz`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line config change affecting image tag strings only; behavior is stricter sanitization with low blast radius outside CI/docker tagging.
> 
> **Overview**
> **`current_branch`** now normalizes git/CI branch names into Docker-safe tag segments instead of only swapping `/` for `-`.
> 
> Any run of characters outside letters, digits, and `_` becomes a single `-`, and leading/trailing `-` are removed. That value still feeds **pull**, **cache**, and **publish** image tags like `base-<branch>`.
> 
> Example: `$feat/foo$%^&#bar--baz--` → `feat-foo-bar-baz`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57560c19cce6ad03d1ca690ce102ddd40b0e2e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->